### PR TITLE
local: update documentation for new endpoints

### DIFF
--- a/local.md
+++ b/local.md
@@ -7,8 +7,8 @@ All requests must be submitted via HTTP GET to `localhost` with a default port o
 All requests must ensure compliance with the following:
 
 - Must have the `Host` header set as `localhost:1547` (or other port as mentioned above).
--  Must have the `User-Agent` header set descriptively, this will be shown on the in-game consent prompt.
--  Must set the `Authorization` header to a random value unique to each session of the application.
+- Must have the `User-Agent` header set descriptively, this will be shown on the in-game consent prompt.
+- Must set the `Authorization` header to a random value unique to each session of the application.
 
 Requests which do not honour these requirements will be rejected by the API server.
 

--- a/local.md
+++ b/local.md
@@ -14,18 +14,34 @@ Requests which do not honour these requirements will be rejected by the API serv
 
 When possible the API server listens on both `127.0.0.1` and `::1`, with a bias towards IPv6.
 
+## GET `/all.json`
+
+| Name | Details |
+|------|---------|
+| [toon](#get-toonjson) | Toon details. |
+| [laff](#get-laffjson) | Toon laff. |
+| [location](#get-locationjson) | Toon location and District. |
+| [gags](#get-gagsjson) | Toon Gag details. |
+| [tasks](#get-tasksjson) | Toon Task details. |
+| [invasion](#get-invasionjson) | District invasion details, or `null` if no invasion active. |
+| [fish](#get-fishjson) | Toon Fish details. |
+| [flowers](#get-flowersjson) | Toon Flower details. |
+| [cogsuits](#get-cogsuitsjson) | Toon Cogsuit details. |
+| [golf](#get-golfjson) | Toon Golf details. |
+| [racing](#get-racingjson) | Toon Racing details. |
+
 ## GET `/info.json`
 
 | Name | Details |
 |------|---------|
-| toon | Toon details. |
-| laff | Toon laff. |
-| location | Toon location and District. |
-| gags | Toon Gag details. |
-| tasks | Toon Task details. |
-| invasion | District invasion details, or `null` if no invasion active.
+| [toon](#get-toonjson) | Toon details. |
+| [laff](#get-laffjson) | Toon laff. |
+| [location](#get-locationjson) | Toon location and District. |
+| [gags](#get-gagsjson) | Toon Gag details. |
+| [tasks](#get-tasksjson) | Toon Task details. |
+| [invasion](#get-invasionjson) | District invasion details, or `null` if no invasion active. |
 
-### `toon` Values
+## GET `/toon.json`
 
 | Name | Description |
 |------|-------------|
@@ -34,14 +50,14 @@ When possible the API server listens on both `127.0.0.1` and `::1`, with a bias 
 | headColor | Toon head color in hex format. |
 | style | Toon DNA string for use with Rendition. |
 
-### `laff` Values
+## GET `/laff.json`
 
 | Name | Description |
 |------|-------------|
 | current | Current Toon laff. |
 | max | Maximum Toon laff. |
 
-### `location` Values
+## GET `/location.json`
 
 | Name | Description |
 |------|-------------|
@@ -49,7 +65,7 @@ When possible the API server listens on both `127.0.0.1` and `::1`, with a bias 
 | neighborhood | Neighborhood as a string, for example `Toontown Central`. |
 | district | District as a string, for example `Zapwood`. |
 
-### `gags` Values
+## GET `/gags.json`
 
 `gags` contains a dictionary of Gags with the value being either `null` if the Toon does not have access to that track, or an object with the following values if they do.
 
@@ -59,32 +75,32 @@ When possible the API server listens on both `127.0.0.1` and `::1`, with a bias 
 | organic | `gag` object or `null` if no organic Gags in the track. |
 | experience | `experience` object. |
 
-#### `gag` Values
+### `gag` Values
 
 | Name | Description |
 |------|-------------|
 | level | Level as an integer of the highest Gag unlocked/organic in the track, starting at 1. |
 | name | Localised name of the highest Gag unlocked/organic in the track. |
 
-#### `experience` Values
+### `experience` Values
 
 | Name | Description |
 |------|-------------|
 | current | Current experience as an integer. |
 | next | Next milestone as an integer. |
 
-### `tasks` Values
+## GET `/tasks.json`
 
 `tasks` is an array of `task` objects.
 
-#### `task` Values
+### `task` Values
 
 | Name | Description |
 |------|-------------|
 | objective | `objective` object. |
 | from | `npc` object containing the NPC the task was accepted from. |
 | to | `npc` object containing the NPC the task will be turned in to. |
-| reward | Localised reward text for the task. |
+| reward | Localised reward text for the task or `null` if there is no reward. |
 | deletable | Boolean indicating if the task can be deleted from the Shticker book. |
 
 #### `objective` Values
@@ -112,10 +128,118 @@ When possible the API server listens on both `127.0.0.1` and `::1`, with a bias 
 | zone | Localised zone name where the NPC is situated. |
 | neighborhood | Localised neighborhood name where the NPC is situated. |
 
-### `invasion` Values
+## GET `/invasion.json`
 
 | Name | Description |
 |------|-------------|
 | cog | Name of invading Cog, for example `Version 2.0 Flunky`. |
 | quantity | The total amount of Cogs invading the District. |
 | mega | Boolean value indicating if it's a mega-invasion. |
+
+## GET `/fish.json`
+
+| Name       | Description |
+|------------|-------------|
+| rod        | `rod` object containing details about the fishing rod. |
+| collection | Dictionary where keys are fish IDs and values are `fish` objects. |
+
+### `rod` Values
+
+| Name | Description |
+|------|-------------|
+| id   | Identifier for the fishing rod. |
+| name | Localised name of the fishing rod. |
+
+#### `fish` Values
+
+| Name      | Description |
+|-----------|-------------|
+| name      | Localised name of the fish species. |
+| album     | Dictionary where keys are subspecies IDs and values are subspecies objects. |
+
+#### `subspecies` Values
+
+| Name   | Description |
+|--------|-------------|
+| name   | Localised name of the fish variant. |
+| weight | Weight of the fish variant in ounces. |
+
+## GET `/flowers.json`
+
+| Name          | Description |
+|---------------|-------------|
+| shovel        | `shovel` object containing details about the player's shovel. |
+| wateringCan   | `wateringCan` object containing details about the player's watering can. |
+| collection    | Dictionary where keys are flower IDs and values are `flower` objects. |
+
+### `shovel` Values
+
+| Name      | Description |
+|-----------|-------------|
+| id        | Identifier for the shovel. |
+| name      | Localised name of the shovel. |
+| curSkill  | Current skill level for the shovel. |
+| maxSkill  | Maximum skill level for the shovel. |
+
+### `wateringCan` Values
+
+| Name      | Description |
+|-----------|-------------|
+| id        | Identifier for the watering can. |
+| name      | Localised name of the watering can. |
+| curSkill  | Current skill level for the watering can. |
+| maxSkill  | Maximum skill level for the watering can. |
+
+### `flower` Values
+
+| Name      | Description |
+|-----------|-------------|
+| name      | Localised name of the flower species. |
+| album     | Dictionary where keys are variant IDs and values are localised variant names. |
+
+## GET `/cogsuits.json`
+
+`cogsuits` contains a dictionary where the keys represent the Cog departments (`c`, `l`, `m`, `s` for Bossbot, Lawbot, Cashbot, and Sellbot). Each value is an object with the following values.
+
+### `cogsuit` Values
+
+| Name         | Description |
+|--------------|-------------|
+| department   | The name of the Cog department |
+| hasDisguise  | Boolean indicating if the Toon has a disguise for this department. |
+| suit         | `suit` object containing details about the Cog suit, or omitted if `hasDisguise` is false. |
+| version      | Version of the Cog suit as an integer, or omitted if `hasDisguise` is false. |
+| level        | Current level of the Cog suit as an integer, or omitted if `hasDisguise` is false.|
+| promotion    | `promotion` object. Omitted if no promotion is available or `hasDisguise` is false. |
+
+#### `suit` Values
+
+| Name | Description |
+|------|-------------|
+| id   | Identifier for the Cog suit. |
+| name | Localised name of the Cog suit. |
+
+#### `promotion` Values
+
+| Name    | Description |
+|---------|-------------|
+| current | Current promotion progress as an integer. |
+| target  | Target promotion progress as an integer. |
+
+## GET `/golf.json`
+
+`golf` is an array of `stats` objects.
+
+| Name | Description |
+|------|-------------|
+| name | Localised name of the golf statistic. |
+| num  | Numeric value representing the statistic. |
+
+## GET `/racing.json`
+
+`racing` is an array of `stats` objects.
+
+| Name | Description |
+|------|-------------|
+| name | Localised name of the racing statistic. |
+| num  | Numeric value representing the statistic. |


### PR DESCRIPTION
Updates documentation to include all new endpoints and their returns. Adds anchors to `/all.json`'s and `/info.json`'s returns to quickly reference nested endpoints. 

Removes extra whitespace regarding User Agent and Authorization request information.

New endpoints:
- all
- fish
- flowers
- cogsuits
- golf
- racing

Updated endpoints:
- info: adds anchors to nested endpoint returns and move the original documentation to their respective endpoint (specifically, toon, laff, location, gags, tasks, and invasion)
- tasks: clarify `task.reward` returns `null` if no reward is given