### PR TITLE
Add docs for the News API

### DIFF
--- a/news.md
+++ b/news.md
@@ -1,0 +1,30 @@
+# Toontown Rewritten News API
+
+## Requests
+
+All requests must be submitted via HTTP GET to `https://www.toontownrewritten.com/api` with one of the following endpoints.
+
+If you are frequently making calls to this API, we would appreciate it if you set a descriptive User-Agent.
+
+## GET `/news`
+
+Returns the latest `news` object.
+
+## GET `/news/{postId}`
+
+Uses `postId` to retrieve the corresponding `news` object. If no post is found, the text `null` is returned instead.
+
+## GET `/news/list`
+
+Returns an array of all `news` objects.
+
+## `news` Values
+
+| Name | Description |
+|------|-------------|
+| postId | Identifier for the news post. |
+| title | Title of the news post. |
+| author | Author of the news post. |
+| body | HTML contents of the release note as a string. |
+| date | Date and time the news post was published as a string, for example `June 15, 2025 at 12:00 PM`. |
+| image | URL of the first image in the news post as a string, for example `https://cdn.toontownrewritten.com/media/news-site/img/25-06-15_pridedayteamspotlight.png`. |


### PR DESCRIPTION
Resolves #8 

Note: Despite existing documentation located at https://toontownrewritten.com/api/docs#/default/list_api_news_list_get suggesting that there are optional `limit` and `page` parameters available for `/news/list`, using them does **not** have any affect on the results returned by the API. Thus, I chose to omit them from this PR.

Due to the sheer size of the response (currently ~3.79MiB), if these parameters are intentionally unavailable, it may be wise to add a warning to the docs that retrieving the full list of news articles may be slow and shouldn't be requested too frequently.