### PR TITLE
local: Add missing toon `id` field

### DIFF
--- a/local.md
+++ b/local.md
@@ -48,6 +48,7 @@ When possible the API server listens on both `127.0.0.1` and `::1`, with a bias 
 
 | Name | Description |
 |------|-------------|
+| id | Toon identifier, for example `TTID-ABCD-EFGH`. |
 | name | Toon name. |
 | species | Toon species name. |
 | headColor | Toon head color in hex format. |


### PR DESCRIPTION
Noticed that the API returns the toon's ID, but it's not mentioned in the docs.

I didn't see any other discrepancies with the rest of the Local endpoints.